### PR TITLE
Feature/cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/node_modules
 credentials.json
+deployment
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 credentials.json
 deployment
 .DS_Store
+services

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,5 @@
   "arrowParens": "always",
   "trailingComma": "es5",
   "jsxBracketSameLine": true,
-  "printWidth": 80
+  "printWidth": 100
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ bedrock create \
   seltzer-box
 ```
 
+## Cloud Deployment
+
+To use the bedrock `cloud` commands, check the `bedrock-core` Deployment [README.md](https://github.com/bedrockio/bedrock-core/tree/master/deployment), which includes: gcloud setup, deployment and provisioning.
+
 ## More
 
 ```bash

--- a/bin/bedrock
+++ b/bin/bedrock
@@ -3,6 +3,7 @@
 require = require('esm')(module);
 
 const path = require('path');
+const kleur = require('kleur');
 const { program } = require('commander');
 const { camelCase } = require('lodash');
 const { promptFill } = require('../src/util/prompt');
@@ -59,8 +60,12 @@ function addCommand(command, descriptor) {
           options[args[0].name] = subcommand.args;
         } else if (sub.arguments) {
           subcommand.args.forEach((arg, i) => {
-            const { name } = sub.arguments[i];
-            options[name] = arg;
+            if (sub.arguments[i]) {
+              const { name } = sub.arguments[i];
+              options[name] = arg;
+            } else {
+              console.info(kleur.yellow(`Warning: "${arg}" argument not used`));
+            }
           });
         }
         if (snapshot) {
@@ -82,9 +87,7 @@ function getHandler(descriptor) {
   if (parent.name === 'bedrock') {
     return require(path.resolve(__dirname, '../src', name)).default;
   } else {
-    return require(path.resolve(__dirname, '../src', parent.name))[
-      camelCase(name)
-    ];
+    return require(path.resolve(__dirname, '../src', parent.name))[camelCase(name)];
   }
 }
 

--- a/command.json
+++ b/command.json
@@ -264,6 +264,40 @@
               "prompt": false
             }
           ]
+        },
+        {
+          "name": "deploy",
+          "description": "Rollout deployment to cluster",
+          "arguments": [
+            {
+              "name": "environment",
+              "type": "string",
+              "description": "Environment (e.g. staging)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "service",
+              "type": "string",
+              "description": "Service (e.g. api)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "subservice",
+              "type": "string",
+              "description": "SubService (e.g. cli)",
+              "required": false,
+              "prompt": false
+            },
+            {
+              "name": "tag",
+              "type": "string",
+              "description": "Image Tag, defaults to latest (e.g. v1.2)",
+              "required": false,
+              "prompt": false
+            }
+          ]
         }
       ]
     }

--- a/command.json
+++ b/command.json
@@ -161,7 +161,7 @@
               "name": "environment",
               "type": "string",
               "description": "Environment (e.g. staging)",
-              "required": true,
+              "required": false,
               "prompt": false
             }
           ]
@@ -174,7 +174,7 @@
               "name": "environment",
               "type": "string",
               "description": "Environment (e.g. staging)",
-              "required": true,
+              "required": false,
               "prompt": false
             }
           ]
@@ -187,7 +187,7 @@
               "name": "service",
               "type": "string",
               "description": "Service (e.g. api)",
-              "required": true,
+              "required": false,
               "prompt": false
             },
             {
@@ -214,7 +214,7 @@
               "name": "environment",
               "type": "string",
               "description": "Environment (e.g. staging)",
-              "required": true,
+              "required": false,
               "prompt": false
             },
             {
@@ -248,14 +248,14 @@
               "name": "environment",
               "type": "string",
               "description": "Environment (e.g. staging)",
-              "required": true,
+              "required": false,
               "prompt": false
             },
             {
               "name": "service",
               "type": "string",
               "description": "Service (e.g. api)",
-              "required": true,
+              "required": false,
               "prompt": false
             },
             {
@@ -275,14 +275,14 @@
               "name": "environment",
               "type": "string",
               "description": "Environment (e.g. staging)",
-              "required": true,
+              "required": false,
               "prompt": false
             },
             {
               "name": "service",
               "type": "string",
               "description": "Service (e.g. api)",
-              "required": true,
+              "required": false,
               "prompt": false
             },
             {
@@ -309,14 +309,14 @@
               "name": "environment",
               "type": "string",
               "description": "Environment (e.g. staging)",
-              "required": true,
+              "required": false,
               "prompt": false
             },
             {
               "name": "service",
               "type": "string",
               "description": "Service (e.g. api)",
-              "required": true,
+              "required": false,
               "prompt": false
             },
             {
@@ -363,14 +363,14 @@
               "name": "environment",
               "type": "string",
               "description": "Environment (e.g. staging)",
-              "required": true,
+              "required": false,
               "prompt": false
             },
             {
               "name": "terraform",
               "type": "string",
               "description": "Terraform command (e.g. apply or plan)",
-              "required": true,
+              "required": false,
               "prompt": false
             }
           ]
@@ -383,7 +383,7 @@
               "name": "environment",
               "type": "string",
               "description": "Environment (e.g. staging)",
-              "required": true,
+              "required": false,
               "prompt": false
             },
             {

--- a/command.json
+++ b/command.json
@@ -300,6 +300,33 @@
           ]
         },
         {
+          "name": "undeploy",
+          "description": "Delete deployment from cluster",
+          "arguments": [
+            {
+              "name": "environment",
+              "type": "string",
+              "description": "Environment (e.g. staging)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "service",
+              "type": "string",
+              "description": "Service (e.g. api)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "subservice",
+              "type": "string",
+              "description": "SubService (e.g. cli)",
+              "required": false,
+              "prompt": false
+            }
+          ]
+        },
+        {
           "name": "info",
           "description": "Deployment info",
           "arguments": [

--- a/command.json
+++ b/command.json
@@ -399,6 +399,33 @@
               "prompt": false
             }
           ]
+        },
+        {
+          "name": "logs",
+          "description": "Open Google Cloud logs explorer UI in your browser",
+          "arguments": [
+            {
+              "name": "environment",
+              "type": "string",
+              "description": "Environment (e.g. staging)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "service",
+              "type": "string",
+              "description": "Service (e.g. api)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "subservice",
+              "type": "string",
+              "description": "SubService (e.g. cli)",
+              "required": false,
+              "prompt": false
+            }
+          ]
         }
       ]
     }

--- a/command.json
+++ b/command.json
@@ -203,6 +203,40 @@
               "prompt": false
             }
           ]
+        },
+        {
+          "name": "push",
+          "description": "Push service container to gcr.io",
+          "arguments": [
+            {
+              "name": "environment",
+              "type": "string",
+              "description": "Environment (e.g. staging)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "service",
+              "type": "string",
+              "description": "Service (e.g. api)",
+              "required": false,
+              "prompt": false
+            },
+            {
+              "name": "subservice",
+              "type": "string",
+              "description": "SubService (e.g. cli)",
+              "required": false,
+              "prompt": false
+            },
+            {
+              "name": "tag",
+              "type": "string",
+              "description": "Image Tag, defaults to latest (e.g. v1.2)",
+              "required": false,
+              "prompt": false
+            }
+          ]
         }
       ]
     }

--- a/command.json
+++ b/command.json
@@ -325,6 +325,26 @@
               "prompt": false
             }
           ]
+        },
+        {
+          "name": "provision",
+          "description": "Deployment info",
+          "arguments": [
+            {
+              "name": "environment",
+              "type": "string",
+              "description": "Environment (e.g. staging)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "terraform",
+              "type": "string",
+              "description": "Terraform command (e.g. apply or plan)",
+              "required": true,
+              "prompt": false
+            }
+          ]
         }
       ]
     }

--- a/command.json
+++ b/command.json
@@ -240,7 +240,7 @@
         },
         {
           "name": "rollout",
-          "description": "Rollout deployment to cluster",
+          "description": "Rollout service to cluster",
           "arguments": [
             {
               "name": "environment",
@@ -267,7 +267,7 @@
         },
         {
           "name": "deploy",
-          "description": "Rollout deployment to cluster",
+          "description": "Build, push and rollout service to cluster",
           "arguments": [
             {
               "name": "environment",
@@ -301,7 +301,7 @@
         },
         {
           "name": "undeploy",
-          "description": "Delete deployment from cluster",
+          "description": "Delete service from cluster",
           "arguments": [
             {
               "name": "environment",
@@ -355,7 +355,7 @@
         },
         {
           "name": "provision",
-          "description": "Deployment info",
+          "description": "Provision cluster on glcoud with Terraform",
           "arguments": [
             {
               "name": "environment",
@@ -375,7 +375,7 @@
         },
         {
           "name": "shell",
-          "description": "Start remote bash shell on deployment container",
+          "description": "Start remote bash shell on service container",
           "arguments": [
             {
               "name": "environment",

--- a/command.json
+++ b/command.json
@@ -237,6 +237,33 @@
               "prompt": false
             }
           ]
+        },
+        {
+          "name": "rollout",
+          "description": "Rollout deployment to cluster",
+          "arguments": [
+            {
+              "name": "environment",
+              "type": "string",
+              "description": "Environment (e.g. staging)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "service",
+              "type": "string",
+              "description": "Service (e.g. api)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "subservice",
+              "type": "string",
+              "description": "SubService (e.g. cli)",
+              "required": false,
+              "prompt": false
+            }
+          ]
         }
       ]
     }

--- a/command.json
+++ b/command.json
@@ -146,6 +146,38 @@
           ]
         }
       ]
+    },
+    {
+      "name": "cloud",
+      "description": "Cloud Controls for deployment and provisioning",
+      "commands": [
+        {
+          "name": "authorize",
+          "description": "Authorize cloud environment",
+          "arguments": [
+            {
+              "name": "environment",
+              "type": "string",
+              "description": "Environment (e.g. staging)",
+              "required": true,
+              "prompt": false
+            }
+          ]
+        },
+        {
+          "name": "status",
+          "description": "Get status of cloud deployment",
+          "arguments": [
+            {
+              "name": "environment",
+              "type": "string",
+              "description": "Environment (e.g. staging)",
+              "required": true,
+              "prompt": false
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/command.json
+++ b/command.json
@@ -176,6 +176,33 @@
               "prompt": false
             }
           ]
+        },
+        {
+          "name": "build",
+          "description": "Build service container",
+          "arguments": [
+            {
+              "name": "service",
+              "type": "string",
+              "description": "Service (e.g. api)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "subservice",
+              "type": "string",
+              "description": "SubService (e.g. cli)",
+              "required": false,
+              "prompt": false
+            },
+            {
+              "name": "tag",
+              "type": "string",
+              "description": "Image Tag, defaults to latest (e.g. v1.2)",
+              "required": false,
+              "prompt": false
+            }
+          ]
         }
       ]
     }

--- a/command.json
+++ b/command.json
@@ -298,6 +298,33 @@
               "prompt": false
             }
           ]
+        },
+        {
+          "name": "info",
+          "description": "Deployment info",
+          "arguments": [
+            {
+              "name": "environment",
+              "type": "string",
+              "description": "Environment (e.g. staging)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "service",
+              "type": "string",
+              "description": "Service (e.g. api)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "subservice",
+              "type": "string",
+              "description": "SubService (e.g. cli)",
+              "required": false,
+              "prompt": false
+            }
+          ]
         }
       ]
     }

--- a/command.json
+++ b/command.json
@@ -336,14 +336,14 @@
               "name": "environment",
               "type": "string",
               "description": "Environment (e.g. staging)",
-              "required": true,
+              "required": false,
               "prompt": false
             },
             {
               "name": "service",
               "type": "string",
               "description": "Service (e.g. api)",
-              "required": true,
+              "required": false,
               "prompt": false
             },
             {

--- a/command.json
+++ b/command.json
@@ -372,6 +372,33 @@
               "prompt": false
             }
           ]
+        },
+        {
+          "name": "shell",
+          "description": "Start remote bash shell on deployment container",
+          "arguments": [
+            {
+              "name": "environment",
+              "type": "string",
+              "description": "Environment (e.g. staging)",
+              "required": true,
+              "prompt": false
+            },
+            {
+              "name": "service",
+              "type": "string",
+              "description": "Service (e.g. api)",
+              "required": false,
+              "prompt": false
+            },
+            {
+              "name": "subservice",
+              "type": "string",
+              "description": "SubService (e.g. cli)",
+              "required": false,
+              "prompt": false
+            }
+          ]
         }
       ]
     }

--- a/install
+++ b/install
@@ -41,6 +41,18 @@ _() {
       echo 'Error: Either yarn or npm must be installed (https://www.npmjs.com/)' >&2
       exit 1
     fi
+    if ! [ -x "$(command -v terraform)" ]; then
+      echo 'Error: Terraform is not installed (https://www.terraform.io/)' >&2
+      exit 1
+    fi
+    if ! [ -x "$(command -v gcloud)" ]; then
+      echo 'Error: Google Cloud SDK (gcloud) is not installed (https://cloud.google.com/sdk/docs/install)' >&2
+      exit 1
+    fi
+    if ! [ -x "$(command -v kubectl)" ]; then
+      echo 'Error: Kubernetes CLI (kubectl) is not installed (https://kubernetes.io/docs/tasks/tools/install-kubectl/)' >&2
+      exit 1
+    fi
   }
 
   install () {
@@ -75,7 +87,7 @@ _() {
     try_profile $HOME/.bash_profile
     try_profile $HOME/.zshenv
     try_profile $HOME/.zshrc
-    try_fish_profile $HOME/.config/fish/config.fish  
+    try_fish_profile $HOME/.config/fish/config.fish
   }
 
 

--- a/install
+++ b/install
@@ -41,10 +41,6 @@ _() {
       echo 'Error: Either yarn or npm must be installed (https://www.npmjs.com/)' >&2
       exit 1
     fi
-    if ! [ -x "$(command -v terraform)" ]; then
-      echo 'Error: Terraform is not installed (https://www.terraform.io/)' >&2
-      exit 1
-    fi
     if ! [ -x "$(command -v gcloud)" ]; then
       echo 'Error: Google Cloud SDK (gcloud) is not installed (https://cloud.google.com/sdk/docs/install)' >&2
       exit 1

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "commander": "^6.1.0",
+    "compare-versions": "^3.6.0",
     "esm": "^3.2.25",
     "execa": "^4.0.3",
     "glob": "^7.1.6",

--- a/src/cloud/authorize.js
+++ b/src/cloud/authorize.js
@@ -6,19 +6,18 @@ export async function setGCloudConfig(options) {
   const { project, computeZone, kubernetes } = options;
   if (!kubernetes) exit('Missing kubernetes settings in config');
   try {
-    const stdErr = true; // gcloud returns output on stderr
-
+    // gcloud returns output on stderr
     if (!project) exit('Missing project');
-    console.log(await exec(`gcloud config set project ${project}`, stdErr));
+    console.log(await exec(`gcloud config set project ${project}`, 'stderr'));
 
     if (!computeZone) exit('Missing computeZone');
-    console.info(await exec(`gcloud config set compute/zone ${computeZone}`, stdErr));
+    console.info(await exec(`gcloud config set compute/zone ${computeZone}`, 'stderr'));
 
     const { clusterName } = kubernetes;
     if (!clusterName) exit('Missing kubernetes.clusterName');
 
-    console.info(await exec(`gcloud container clusters get-credentials ${clusterName}`, stdErr));
-    console.info(await exec(`gcloud config set container/cluster ${clusterName}`, stdErr));
+    console.info(await exec(`gcloud container clusters get-credentials ${clusterName}`, 'stderr'));
+    console.info(await exec(`gcloud config set container/cluster ${clusterName}`, 'stderr'));
   } catch (e) {
     exit(e.message);
   }

--- a/src/cloud/authorize.js
+++ b/src/cloud/authorize.js
@@ -23,7 +23,7 @@ export async function setGCloudConfig(options = {}) {
   try {
     // gcloud returns output on stderr
     if (!project) exit('Missing project');
-    console.log(await exec(`gcloud config set project ${project}`, 'stderr'));
+    console.info(await exec(`gcloud config set project ${project}`, 'stderr'));
 
     if (!computeZone) exit('Missing computeZone');
     console.info(await exec(`gcloud config set compute/zone ${computeZone}`, 'stderr'));

--- a/src/cloud/authorize.js
+++ b/src/cloud/authorize.js
@@ -81,8 +81,6 @@ async function checkGCloudConfig(environment, options = {}) {
       );
     }
 
-    // TODO: add check for secrets folder: deployment/environments/$ENVIRONMENT/secrets
-
     if (valid) {
       console.info(
         kleur.green(
@@ -104,15 +102,15 @@ async function checkSecrets(environment) {
   if (fs.existsSync(secretsDir)) {
     const secretFiles = await exec(`ls ${secretsDir}`);
     if (secretFiles) {
-      console.info(kleur.yellow('---'));
-      console.info(kleur.yellow('---'));
+      console.info(kleur.red('---'));
+      console.info(kleur.red('---'));
       console.info(
-        kleur.yellow(
+        kleur.red(
           `--- Warning: Found files in deployment/environments/${environment}/secrets/ - make sure to remove these!`
         )
       );
-      console.info(kleur.yellow('---'));
-      console.info(kleur.yellow('---'));
+      console.info(kleur.red('---'));
+      console.info(kleur.red('---'));
     }
   }
 }

--- a/src/cloud/authorize.js
+++ b/src/cloud/authorize.js
@@ -101,9 +101,6 @@ async function checkGCloudConfig(environment, options = {}) {
         )
       );
     }
-
-    // TODO: add optional fallback to authorize current values
-
     return valid;
   } catch (e) {
     exit(e.message);

--- a/src/cloud/authorize.js
+++ b/src/cloud/authorize.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import kleur from 'kleur';
 import { exit } from '../util/exit';
@@ -98,9 +99,28 @@ async function checkGCloudConfig(environment, options = {}) {
   }
 }
 
+async function checkSecrets(environment) {
+  const secretsDir = path.resolve('deployment', 'environments', environment, 'secrets');
+  if (fs.existsSync(secretsDir)) {
+    const secretFiles = await exec(`ls ${secretsDir}`);
+    if (secretFiles) {
+      console.info(kleur.yellow('---'));
+      console.info(kleur.yellow('---'));
+      console.info(
+        kleur.yellow(
+          `--- Warning: Found files in deployment/environments/${environment}/secrets/ - make sure to remove these!`
+        )
+      );
+      console.info(kleur.yellow('---'));
+      console.info(kleur.yellow('---'));
+    }
+  }
+}
+
 export async function checkConfig(environment, config) {
   if (!config) exit('Missing config');
   if (!config.gcloud) exit('Missing gcloud field in config');
+  await checkSecrets(environment);
   const valid = await checkGCloudConfig(environment, config.gcloud);
   if (!valid) process.exit(1);
 }

--- a/src/cloud/authorize.js
+++ b/src/cloud/authorize.js
@@ -1,0 +1,78 @@
+import { exit } from '../util/exit';
+import kleur from 'kleur';
+import { exec } from '../util/shell';
+
+export async function setGCloudConfig(options) {
+  const { project, computeZone, kubernetes } = options;
+  if (!kubernetes) exit('Missing kubernetes settings in config');
+  try {
+    const stdErr = true; // gcloud returns output on stderr
+
+    if (!project) exit('Missing project');
+    console.log(await exec(`gcloud config set project ${project}`, stdErr));
+
+    if (!computeZone) exit('Missing computeZone');
+    console.info(await exec(`gcloud config set compute/zone ${computeZone}`, stdErr));
+
+    const { clusterName } = kubernetes;
+    if (!clusterName) exit('Missing kubernetes.clusterName');
+
+    console.info(await exec(`gcloud container clusters get-credentials ${clusterName}`, stdErr));
+    console.info(await exec(`gcloud config set container/cluster ${clusterName}`, stdErr));
+  } catch (e) {
+    exit(e.message);
+  }
+}
+
+export async function checkGCloudConfig(environment, options) {
+  const { project, computeZone, kubernetes } = options;
+  if (!kubernetes) exit('Missing kubernetes settings in config');
+  try {
+    let valid = true;
+    if (!project) exit('Missing project');
+    const currentProject = await exec('gcloud config get-value project');
+    if (project != currentProject) {
+      valid = false;
+      console.info(
+        kleur.red(`Invalid Google Cloud config (use authorize script): project = ${currentProject}`)
+      );
+    }
+
+    if (!computeZone) exit('Missing computeZone');
+    const currentComputeZone = await exec('gcloud config get-value compute/zone');
+    if (computeZone != currentComputeZone) {
+      valid = false;
+      console.info(
+        kleur.red(
+          `Invalid Google Cloud config (use authorize script): compute/zone = ${currentComputeZone}`
+        )
+      );
+    }
+
+    const { clusterName } = kubernetes;
+    if (!clusterName) exit('Missing kubernetes.clusterName');
+    const currentClusterName = await exec('gcloud config get-value container/cluster');
+    if (clusterName != currentClusterName) {
+      valid = false;
+      console.info(
+        kleur.red(
+          `Invalid Google Cloud config (use authorize script): container/cluster = ${currentClusterName}`
+        )
+      );
+    }
+
+    // TODO: add check for secrets folder: deployment/environments/$ENVIRONMENT/secrets
+
+    console.info(
+      kleur.green(
+        `Using Google Cloud environment ${environment} (project=${project}, compute/zone=${computeZone}, cluster=${clusterName})`
+      )
+    );
+
+    // TODO: add optional fallback to authorize current values
+
+    return valid;
+  } catch (e) {
+    exit(e.message);
+  }
+}

--- a/src/cloud/authorize.js
+++ b/src/cloud/authorize.js
@@ -1,6 +1,21 @@
-import { exit } from '../util/exit';
+import path from 'path';
 import kleur from 'kleur';
+import { exit } from '../util/exit';
 import { exec } from '../util/shell';
+import { readFile } from '../util/file';
+
+export async function getConfig(environment) {
+  const configFilePath = path.resolve('deployment/environments', environment, 'config.json');
+  let config = {};
+  try {
+    config = await readFile(configFilePath);
+  } catch (e) {
+    exit(
+      `Could not find config.json for environment: "${environment}", file path: "${configFilePath}"`
+    );
+  }
+  return config;
+}
 
 export async function setGCloudConfig(options) {
   const { project, computeZone, kubernetes } = options;
@@ -23,7 +38,7 @@ export async function setGCloudConfig(options) {
   }
 }
 
-export async function checkGCloudConfig(environment, options) {
+async function checkGCloudConfig(environment, options) {
   const { project, computeZone, kubernetes } = options;
   if (!kubernetes) exit('Missing kubernetes settings in config');
   try {
@@ -74,4 +89,9 @@ export async function checkGCloudConfig(environment, options) {
   } catch (e) {
     exit(e.message);
   }
+}
+
+export async function checkConfig(environment, config) {
+  const valid = await checkGCloudConfig(environment, config.gcloud);
+  if (!valid) exit('Invalid Google Cloud config');
 }

--- a/src/cloud/build.js
+++ b/src/cloud/build.js
@@ -5,12 +5,15 @@ export async function buildImage(platformName, service, subservice, tag = 'lates
   await process.chdir('./services/api');
   if (!subservice) {
     const imageName = `${platformName}-services-${service}:${tag}`;
-    console.info(`\n=> Building "${imageName}"`);
-    console.info(await exec(`docker build -t ${imageName} .`));
+    console.info(kleur.yellow(`\n=> Building "${imageName}"`));
+    require('child_process').execSync(`docker build -t ${imageName} .`, { stdio: 'inherit' });
   } else {
     const imageName = `${platformName}-services-${service}-${subservice}:${tag}`;
     console.info(kleur.yellow(`\n=> Building "${imageName}"`));
-    console.info(await exec(`docker build -t ${imageName} -f Dockerfile.${subservice} .`));
+    require('child_process').execSync(
+      `docker build -t ${imageName} -f Dockerfile.${subservice} .`,
+      { stdio: 'inherit' }
+    );
   }
   await process.chdir('../..');
 }

--- a/src/cloud/build.js
+++ b/src/cloud/build.js
@@ -1,19 +1,16 @@
 import kleur from 'kleur';
-import { exec } from '../util/shell';
+import { execSyncInherit } from '../util/shell';
 
 export async function buildImage(platformName, service, subservice, tag = 'latest') {
   await process.chdir('./services/api');
   if (!subservice) {
     const imageName = `${platformName}-services-${service}:${tag}`;
     console.info(kleur.yellow(`\n=> Building "${imageName}"`));
-    require('child_process').execSync(`docker build -t ${imageName} .`, { stdio: 'inherit' });
+    execSyncInherit(`docker build -t ${imageName} .`);
   } else {
     const imageName = `${platformName}-services-${service}-${subservice}:${tag}`;
     console.info(kleur.yellow(`\n=> Building "${imageName}"`));
-    require('child_process').execSync(
-      `docker build -t ${imageName} -f Dockerfile.${subservice} .`,
-      { stdio: 'inherit' }
-    );
+    execSyncInherit(`docker build -t ${imageName} -f Dockerfile.${subservice} .`);
   }
   await process.chdir('../..');
 }

--- a/src/cloud/build.js
+++ b/src/cloud/build.js
@@ -1,14 +1,15 @@
+import kleur from 'kleur';
 import { exec } from '../util/shell';
 
-export async function buildImage(platformName, service, subservice, tag) {
+export async function buildImage(platformName, service, subservice, tag = 'latest') {
   await process.chdir('./services/api');
   if (!subservice) {
     const imageName = `${platformName}-services-${service}:${tag}`;
-    console.info(`=> Building "${imageName}"`);
+    console.info(`\n=> Building "${imageName}"`);
     console.info(await exec(`docker build -t ${imageName} .`));
   } else {
     const imageName = `${platformName}-services-${service}-${subservice}:${tag}`;
-    console.info(`=> Building "${imageName}"`);
+    console.info(kleur.yellow(`\n=> Building "${imageName}"`));
     console.info(await exec(`docker build -t ${imageName} -f Dockerfile.${subservice} .`));
   }
   await process.chdir('../..');

--- a/src/cloud/build.js
+++ b/src/cloud/build.js
@@ -1,8 +1,16 @@
+import fs from 'fs';
+import path from 'path';
 import kleur from 'kleur';
 import { execSyncInherit } from '../util/shell';
+import { exit } from '../util/exit';
 
 export async function buildImage(platformName, service, subservice, tag = 'latest') {
-  await process.chdir('./services/api');
+  const serviceDir = path.resolve('services', service);
+  if (!fs.existsSync(serviceDir)) {
+    exit(`Service ${service} does not exist`);
+  }
+  await process.chdir(serviceDir);
+
   if (!subservice) {
     const imageName = `${platformName}-services-${service}:${tag}`;
     console.info(kleur.yellow(`\n=> Building "${imageName}"`));
@@ -10,6 +18,9 @@ export async function buildImage(platformName, service, subservice, tag = 'lates
   } else {
     const imageName = `${platformName}-services-${service}-${subservice}:${tag}`;
     console.info(kleur.yellow(`\n=> Building "${imageName}"`));
+    if (!fs.existsSync(`Dockerfile.${subservice}`)) {
+      exit(`Subservice does not exist. Dockerfile.${subservice} is missing`);
+    }
     execSyncInherit(`docker build -t ${imageName} -f Dockerfile.${subservice} .`);
   }
   await process.chdir('../..');

--- a/src/cloud/build.js
+++ b/src/cloud/build.js
@@ -1,0 +1,15 @@
+import { exec } from '../util/shell';
+
+export async function buildImage(platformName, service, subservice, tag) {
+  await process.chdir('./services/api');
+  if (!subservice) {
+    const imageName = `${platformName}-services-${service}:${tag}`;
+    console.info(`=> Building "${imageName}"`);
+    console.info(await exec(`docker build -t ${imageName} .`));
+  } else {
+    const imageName = `${platformName}-services-${service}-${subservice}:${tag}`;
+    console.info(`=> Building "${imageName}"`);
+    console.info(await exec(`docker build -t ${imageName} -f Dockerfile.${subservice} .`));
+  }
+  await process.chdir('../..');
+}

--- a/src/cloud/config-example.json
+++ b/src/cloud/config-example.json
@@ -10,7 +10,8 @@
             "minNodeCount": 2,
             "maxNodeCount": 3,
             "machineType": "n2-standard-2"
-        }
+        },
+        "label": "app"
     },
     "platformName": "bedrock-foundation"
 }

--- a/src/cloud/config-example.json
+++ b/src/cloud/config-example.json
@@ -1,0 +1,16 @@
+{
+    "gcloud": {
+        "envName": "staging",
+        "bucketPrefix": "bedrock-foundation",
+        "project": "bedrock-foundation",
+        "computeZone": "us-east1-c",
+        "kubernetes": {
+            "clusterName": "cluster-1",
+            "nodePoolCount": 2,
+            "minNodeCount": 2,
+            "maxNodeCount": 3,
+            "machineType": "n2-standard-2"
+        }
+    },
+    "platformName": "bedrock-foundation"
+}

--- a/src/cloud/deploy.js
+++ b/src/cloud/deploy.js
@@ -1,0 +1,16 @@
+import kleur from 'kleur';
+import { prompt } from '../util/prompt';
+
+export async function warn(environment) {
+  if (environment == 'production') {
+    console.info(kleur.yellow('---------------------------------------------------------\n'));
+    console.info(kleur.yellow('                 Deploying to production!                \n'));
+    console.info(kleur.yellow('---------------------------------------------------------\n'));
+    const confirmed = await prompt({
+      type: 'confirm',
+      name: 'deploy',
+      message: 'Are you sure?',
+    });
+    if (!confirmed) process.exit(0);
+  }
+}

--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -1,15 +1,14 @@
-import fetch from 'node-fetch';
-import fs from 'fs';
 import path from 'path';
 import kleur from 'kleur';
-import tmp from 'tmp';
-import { homedir } from 'os';
-import { prompt } from '../util/prompt';
 import { assertBedrockRoot } from '../util/dir';
 import { readFile } from '../util/file';
 import { exec } from '../util/shell';
 import { exit } from '../util/exit';
 import { setGCloudConfig, checkGCloudConfig } from './authorize';
+import { buildImage } from './build';
+import { dockerPush } from './push';
+
+const devMode = true;
 
 async function getConfig(environment) {
   const configFilePath = path.resolve('deployment/environments', environment, 'config.json');
@@ -24,10 +23,14 @@ async function getConfig(environment) {
   return config;
 }
 
+function getPlatformName() {
+  return path.basename(process.cwd());
+}
+
 export async function authorize(options) {
   const { environment } = options;
+  if (!devMode) await assertBedrockRoot();
 
-  // await assertBedrockRoot();
   const config = await getConfig(environment);
   await setGCloudConfig(config.gcloud);
   console.info(kleur.green(`Successfully authorized ${environment}`));
@@ -35,8 +38,8 @@ export async function authorize(options) {
 
 export async function status(options) {
   const { environment } = options;
+  if (!devMode) assertBedrockRoot();
 
-  // await assertBedrockRoot();
   const config = await getConfig(environment);
   const valid = await checkGCloudConfig(environment, config.gcloud);
   if (!valid) exit('Invalid Google Cloud config');
@@ -49,24 +52,24 @@ export async function status(options) {
   console.info(await exec('kubectl get pods'));
 }
 
-// function buildImage(service, subservice, tag) {}
-
 export async function build(options) {
   const { service, subservice, tag = 'latest' } = options;
+  if (!devMode) await assertBedrockRoot();
 
-  // await assertBedrockRoot();
-  // const config = await getConfig(environment);
-  const platformName = path.basename(process.cwd()); // || config.platformName
-  console.log(platformName);
+  const platformName = getPlatformName();
+  await buildImage(platformName, service, subservice, tag);
+}
 
-  await process.chdir('./services/api');
-  if (!subservice) {
-    const imageName = `${platformName}-services-${service}:${tag}`;
-    console.info(`=> Building "${imageName}"`);
-    console.info(await exec(`docker build -t ${imageName} .`));
-  } else {
-    const imageName = `${platformName}-services-${service}-${subservice}:${tag}`;
-    console.info(`=> Building "${imageName}"`);
-    console.info(await exec(`docker build -t ${imageName} -f Dockerfile.${subservice} .`));
-  }
+export async function push(options) {
+  const { environment, service, subservice, tag = 'latest' } = options;
+  if (!devMode) assertBedrockRoot();
+
+  const config = await getConfig(environment);
+  const valid = await checkGCloudConfig(environment, config.gcloud);
+  if (!valid) exit('Invalid Google Cloud config');
+
+  const platformName = getPlatformName();
+  const { project } = config.gcloud;
+
+  await dockerPush(project, platformName, service, subservice, tag);
 }

--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -2,11 +2,12 @@ import path from 'path';
 import kleur from 'kleur';
 import { assertBedrockRoot } from '../util/dir';
 import { exec, execSyncInherit } from '../util/shell';
-import { prompt } from '../util/prompt';
 import { getConfig, setGCloudConfig, checkConfig, checkGCloudProject } from './authorize';
 import { buildImage } from './build';
 import { dockerPush } from './push';
+import { warn } from './deploy';
 import { rolloutDeployment, getDeployment } from './rollout';
+import { provisionTerraform } from './provision';
 
 const devMode = true;
 
@@ -70,20 +71,6 @@ export async function rollout(options) {
   await rolloutDeployment(environment, service, subservice);
 }
 
-async function warn(environment) {
-  if (environment == 'production') {
-    console.info(kleur.yellow('---------------------------------------------------------\n'));
-    console.info(kleur.yellow('                 Deploying to production!                \n'));
-    console.info(kleur.yellow('---------------------------------------------------------\n'));
-    const confirmed = await prompt({
-      type: 'confirm',
-      name: 'deploy',
-      message: 'Are you sure?',
-    });
-    if (!confirmed) process.exit(0);
-  }
-}
-
 export async function deploy(options) {
   const { environment, service, subservice, tag } = options;
   if (!devMode) assertBedrockRoot();
@@ -122,78 +109,12 @@ export async function info(options) {
   console.log(annotations);
 }
 
-async function plan(options, planFile) {
-  const { project, computeZone, kubernetes, bucketPrefix, envName } = options;
-  // computeZone example: us-east1-c
-  const region = computeZone.slice(0, -2); // e.g. us-east1
-  const zone = computeZone.slice(-1); // e.g. c
-  const { clusterName, nodePoolCount, minNodeCount, maxNodeCount, machineType } = kubernetes;
-  console.info(kleur.green(`=> Planning with planFile: "${planFile}"`));
-  await execSyncInherit(
-    `terraform plan -var "project=${project}" -var "environment=${envName}" -var "cluster_name=${clusterName}" -var "bucket_prefix=${bucketPrefix}" -var "region=${region}" -var "zone=${zone}" -var "node_pool_count=${nodePoolCount}" -var "min_node_count=${minNodeCount}" -var "max_node_count=${maxNodeCount}" -var "machine_type=${machineType}" -out="${planFile}"`
-  );
-}
-
 export async function provision(options) {
   const { environment, terraform } = options;
   if (!devMode) assertBedrockRoot();
 
   const config = await getConfig(environment);
-  const { gcloud } = config;
-  const { project, computeZone, envName, bucketPrefix } = gcloud;
-  await checkGCloudProject(project);
-  const region = computeZone.slice(0, -2);
+  await checkGCloudProject(config.gcloud);
 
-  const planFile = await exec('mktemp');
-  process.chdir(path.resolve('deployment', 'environments', environment, 'provisioning'));
-
-  if (terraform == 'init') {
-    const terraformBucket = `${bucketPrefix}-terraform-system-state`;
-    console.info(kleur.green(`Terraform bucket: ${terraformBucket}`));
-    try {
-      await exec(`gsutil ls gs://${terraformBucket}`);
-    } catch (e) {
-      if (e.message.includes('BucketNotFoundException')) {
-        console.info(kleur.yellow(`${terraformBucket} does not exist. Creating now...`));
-        await exec(`gsutil mb -l ${region} gs://${terraformBucket}`);
-      }
-    }
-    console.info('Initialization can take several minutes...');
-    let command = `terraform init -backend-config="bucket=${terraformBucket}" -backend-config="prefix=${envName}"`;
-    console.info(command);
-    await execSyncInherit(command);
-  } else if (terraform == 'plan') {
-    await plan(gcloud, planFile);
-  } else if (terraform == 'apply') {
-    await plan(gcloud, planFile);
-    console.info(kleur.yellow('---------------------------------------------------------\n'));
-    console.info(kleur.yellow('         Applying plan can take several minutes          \n'));
-    console.info(kleur.yellow('---------------------------------------------------------\n'));
-    console.info(kleur.yellow(`Project: ${project}\nEnvironment: ${environment}\n`));
-
-    let confirmed = await prompt({
-      type: 'confirm',
-      name: 'apply',
-      message: 'Are you sure?',
-    });
-    if (!confirmed) process.exit(0);
-    await execSyncInherit(`terraform apply "${planFile}"`);
-  } else if (terraform == 'destroy') {
-    console.info('Resources to destroy:');
-    await execSyncInherit('terraform state list');
-    console.info(kleur.yellow('---------------------------------------------------------\n'));
-    console.info(kleur.yellow('    Destroying infrastructure can take several minutes   \n'));
-    console.info(kleur.yellow('---------------------------------------------------------\n'));
-    console.info(kleur.yellow(`Project: ${project}\nEnvironment: ${environment}\n`));
-
-    let confirmed = await prompt({
-      type: 'confirm',
-      name: 'destroy',
-      message: 'Are you sure?',
-    });
-    if (!confirmed) process.exit(0);
-    await execSyncInherit(`terraform destroy -auto-approve`);
-  } else {
-    console.info(kleur.yellow(`Terraform command "${terraform}" not supported`));
-  }
+  await provisionTerraform(environment, terraform, config.gcloud);
 }

--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -1,5 +1,5 @@
-import kleur from 'kleur';
 import open from 'open';
+import { green, yellow } from 'kleur';
 import { assertBedrockRoot } from '../util/dir';
 import { exec, execSyncInherit } from '../util/shell';
 import { prompt } from '../util/prompt';
@@ -27,7 +27,7 @@ export async function authorize(options) {
   const environment = options.environment || (await getEnvironmentPrompt());
   const config = await getConfig(environment);
   await setGCloudConfig(config.gcloud);
-  console.info(kleur.green(`Successfully authorized ${environment}`));
+  console.info(green(`Successfully authorized ${environment}`));
 }
 
 export async function status(options) {
@@ -161,7 +161,7 @@ async function showDeploymentInfo(service, subservice) {
   const deploymentInfo = await checkDeployment(service, subservice);
   if (deploymentInfo) {
     const { annotations } = deploymentInfo.spec.template.metadata;
-    console.info(kleur.green(`Deployment "${deployment}" annotations:`));
+    console.info(green(`Deployment "${deployment}" annotations:`));
     console.info(annotations);
   }
 }
@@ -213,7 +213,7 @@ export async function shell(options) {
 
   const podsJSON = await exec(`kubectl get pods -o json --ignore-not-found`);
   if (!podsJSON) {
-    console.info(kleur.yellow(`No running pods`));
+    console.info(yellow(`No running pods`));
     process.exit(0);
   }
   const pods = JSON.parse(podsJSON).items;
@@ -226,12 +226,12 @@ export async function shell(options) {
   const filteredPods = pods.filter((pod) => pod.metadata.name.startsWith(deployment));
 
   if (!filteredPods.length) {
-    console.info(kleur.yellow(`No running pods for deployment "${deployment}"`));
+    console.info(yellow(`No running pods for deployment "${deployment}"`));
     process.exit(0);
   }
 
   const podName = filteredPods[0].metadata.name;
-  console.info(kleur.yellow(`=> Starting bash for pod: "${podName}"`));
+  console.info(yellow(`=> Starting bash for pod: "${podName}"`));
 
   const { spawn } = require('child_process');
 
@@ -240,7 +240,7 @@ export async function shell(options) {
   });
 
   child.on('exit', function (code) {
-    console.info(kleur.green(`Finished bash for pod: "${podName}" (exit code: ${code})`));
+    console.info(green(`Finished bash for pod: "${podName}" (exit code: ${code})`));
   });
 }
 
@@ -261,7 +261,7 @@ export async function logs(options) {
   const params = new URLSearchParams({ query });
 
   const url = `https://console.cloud.google.com/logs/query;${params.toString()}?project=${project}`;
-  console.info(kleur.green(`=> Opening Logs in GCloud UI`));
+  console.info(green(`=> Opening Logs in GCloud UI`));
   console.info(url);
   let confirmed = await prompt({
     type: 'confirm',

--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -108,7 +108,7 @@ export async function info(options) {
   const deploymentInfo = await checkDeployment(service, subservice);
   const { annotations } = deploymentInfo.spec.template.metadata;
   console.info(`Deployment "${deployment}" annotations:`);
-  console.log(annotations);
+  console.info(annotations);
 }
 
 export async function provision(options) {

--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -112,7 +112,7 @@ export async function info(options) {
     `kubectl get deployment ${deployment} -o jsonpath='{@}' --ignore-not-found`
   );
   if (!deploymentInfoJSON) {
-    console.info(`Deployment "${deployment}" could not be found`);
+    console.info(kleur.yellow(`Deployment "${deployment}" could not be found`));
     process.exit(0);
   }
   const deploymentInfo = JSON.parse(deploymentInfoJSON.slice(1, -1));

--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import kleur from 'kleur';
 import { assertBedrockRoot } from '../util/dir';
@@ -72,4 +73,69 @@ export async function push(options) {
   const { project } = config.gcloud;
 
   await dockerPush(project, platformName, service, subservice, tag);
+}
+
+async function getTag() {
+  let tag = await exec('git tag --points-at HEAD');
+  if (!tag) tag = await exec('git rev-parse --short --verify HEAD');
+  const stat = await exec('git diff --stat');
+  if (stat) tag += '-dirty';
+  return tag;
+}
+
+async function getMetaData() {
+  const author = await exec('git config user.name');
+  const date = new Date().toUTCString();
+  const branch = await exec('git branch --show-current');
+  const git = await getTag();
+  let fields = `\\"author\\":\\"${author}\\"`;
+  fields += `,\\"date\\":\\"${date}\\"`;
+  fields += `,\\"branch\\":\\"${branch}\\"`;
+  fields += `,\\"git\\":\\"${git}\\"`;
+  const metaData = `{\\"spec\\":{\\"template\\":{\\"metadata\\":{\\"annotations\\":{${fields}}}}}}`;
+  return metaData;
+}
+
+async function rolloutDeployment(environment, service, subservice) {
+  let deployment = service;
+  if (subservice) deployment += `-${subservice}`;
+  deployment += '-deployment';
+
+  console.info(`Rolling out ${environment} ${deployment}`);
+
+  const deploymentFile = path.resolve(
+    'deployment',
+    'environments',
+    environment,
+    'services',
+    `${deployment}.yml`
+  );
+
+  // Check for config file as it might not exist if the
+  // deployment was dynamically created for a feature branch.
+  if (fs.existsSync(deploymentFile)) {
+    const applyCommand = `kubectl apply -f ${deploymentFile} --record`;
+    // console.info(applyCommand);
+    console.info(await exec(applyCommand));
+  }
+
+  const metaData = await getMetaData();
+  // Patching spec.template forces the container to pull the latest image and
+  // perform a rolling update as long as imagePullPolicy: Always is specified.
+  const patchCommand = `kubectl patch deployment ${deployment} -p "${metaData}" --record`;
+  // console.info(patchCommand);
+  // Note: exec does not work with escaped double quotes
+  const execSync = require('child_process').execSync;
+  console.info(execSync(patchCommand, { encoding: 'utf-8' }));
+}
+
+export async function rollout(options) {
+  const { environment, service, subservice } = options;
+  if (!devMode) assertBedrockRoot();
+
+  const config = await getConfig(environment);
+  const valid = await checkGCloudConfig(environment, config.gcloud);
+  if (!valid) exit('Invalid Google Cloud config');
+
+  await rolloutDeployment(environment, service, subservice);
 }

--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -2,8 +2,9 @@ import path from 'path';
 import kleur from 'kleur';
 import open from 'open';
 import { assertBedrockRoot } from '../util/dir';
-import { exec, execSyncInherit } from '../util/shell';
+import { exec, execSyncPipe, execSyncInherit } from '../util/shell';
 import { prompt } from '../util/prompt';
+import { exit } from '../util/exit';
 import { getConfig, setGCloudConfig, checkConfig, checkGCloudProject } from './authorize';
 import { buildImage } from './build';
 import { dockerPush } from './push';
@@ -119,6 +120,12 @@ export async function provision(options) {
 
   const config = await getConfig(environment);
   await checkGCloudProject(config.gcloud);
+
+  try {
+    await exec('command -v terraform');
+  } catch (e) {
+    exit('Error: Terraform is not installed (https://www.terraform.io/');
+  }
 
   await provisionTerraform(environment, terraform, config.gcloud);
 }

--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -1,0 +1,50 @@
+import fetch from 'node-fetch';
+import fs from 'fs';
+import path from 'path';
+import kleur from 'kleur';
+import tmp from 'tmp';
+import { homedir } from 'os';
+import { prompt } from '../util/prompt';
+import { assertBedrockRoot } from '../util/dir';
+import { readFile } from '../util/file';
+import { exec } from '../util/shell';
+import { exit } from '../util/exit';
+import { setGCloudConfig, checkGCloudConfig } from './authorize';
+
+async function getConfig(environment) {
+  const configFilePath = path.resolve('deployment/environments', environment, 'config.json');
+  let config = {};
+  try {
+    config = await readFile(configFilePath);
+  } catch (e) {
+    exit(
+      `Could not find config.json for environment: "${environment}", file path: "${configFilePath}"`
+    );
+  }
+  return config;
+}
+
+export async function authorize(options) {
+  const { environment } = options;
+
+  // await assertBedrockRoot();
+  const config = await getConfig(environment);
+  await setGCloudConfig(config.gcloud);
+  console.info(kleur.green(`Successfully authorized ${environment}`));
+}
+
+export async function status(options) {
+  const { environment } = options;
+
+  // await assertBedrockRoot();
+  const config = await getConfig(environment);
+  const valid = await checkGCloudConfig(environment, config.gcloud);
+  if (!valid) exit('Invalid Google Cloud config');
+
+  const ingress = await exec('kubectl get ingress');
+  if (ingress) console.info(ingress, '\n');
+
+  console.info(await exec('kubectl get services'), '\n');
+  console.info(await exec('kubectl get nodes'), '\n');
+  console.info(await exec('kubectl get pods'));
+}

--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -1,28 +1,13 @@
-import fs from 'fs';
 import path from 'path';
 import kleur from 'kleur';
 import { assertBedrockRoot } from '../util/dir';
-import { readFile } from '../util/file';
 import { exec } from '../util/shell';
-import { exit } from '../util/exit';
-import { setGCloudConfig, checkGCloudConfig } from './authorize';
+import { getConfig, setGCloudConfig, checkConfig } from './authorize';
 import { buildImage } from './build';
 import { dockerPush } from './push';
+import { rolloutDeployment } from './rollout';
 
 const devMode = true;
-
-async function getConfig(environment) {
-  const configFilePath = path.resolve('deployment/environments', environment, 'config.json');
-  let config = {};
-  try {
-    config = await readFile(configFilePath);
-  } catch (e) {
-    exit(
-      `Could not find config.json for environment: "${environment}", file path: "${configFilePath}"`
-    );
-  }
-  return config;
-}
 
 function getPlatformName() {
   return path.basename(process.cwd());
@@ -42,8 +27,7 @@ export async function status(options) {
   if (!devMode) assertBedrockRoot();
 
   const config = await getConfig(environment);
-  const valid = await checkGCloudConfig(environment, config.gcloud);
-  if (!valid) exit('Invalid Google Cloud config');
+  await checkConfig(environment, config);
 
   const ingress = await exec('kubectl get ingress');
   if (ingress) console.info(ingress, '\n');
@@ -58,6 +42,7 @@ export async function build(options) {
   if (!devMode) await assertBedrockRoot();
 
   const platformName = getPlatformName();
+
   await buildImage(platformName, service, subservice, tag);
 }
 
@@ -66,67 +51,11 @@ export async function push(options) {
   if (!devMode) assertBedrockRoot();
 
   const config = await getConfig(environment);
-  const valid = await checkGCloudConfig(environment, config.gcloud);
-  if (!valid) exit('Invalid Google Cloud config');
-
-  const platformName = getPlatformName();
+  await checkConfig(environment, config);
   const { project } = config.gcloud;
+  const platformName = getPlatformName();
 
   await dockerPush(project, platformName, service, subservice, tag);
-}
-
-async function getTag() {
-  let tag = await exec('git tag --points-at HEAD');
-  if (!tag) tag = await exec('git rev-parse --short --verify HEAD');
-  const stat = await exec('git diff --stat');
-  if (stat) tag += '-dirty';
-  return tag;
-}
-
-async function getMetaData() {
-  const author = await exec('git config user.name');
-  const date = new Date().toUTCString();
-  const branch = await exec('git branch --show-current');
-  const git = await getTag();
-  let fields = `\\"author\\":\\"${author}\\"`;
-  fields += `,\\"date\\":\\"${date}\\"`;
-  fields += `,\\"branch\\":\\"${branch}\\"`;
-  fields += `,\\"git\\":\\"${git}\\"`;
-  const metaData = `{\\"spec\\":{\\"template\\":{\\"metadata\\":{\\"annotations\\":{${fields}}}}}}`;
-  return metaData;
-}
-
-async function rolloutDeployment(environment, service, subservice) {
-  let deployment = service;
-  if (subservice) deployment += `-${subservice}`;
-  deployment += '-deployment';
-
-  console.info(`Rolling out ${environment} ${deployment}`);
-
-  const deploymentFile = path.resolve(
-    'deployment',
-    'environments',
-    environment,
-    'services',
-    `${deployment}.yml`
-  );
-
-  // Check for config file as it might not exist if the
-  // deployment was dynamically created for a feature branch.
-  if (fs.existsSync(deploymentFile)) {
-    const applyCommand = `kubectl apply -f ${deploymentFile} --record`;
-    // console.info(applyCommand);
-    console.info(await exec(applyCommand));
-  }
-
-  const metaData = await getMetaData();
-  // Patching spec.template forces the container to pull the latest image and
-  // perform a rolling update as long as imagePullPolicy: Always is specified.
-  const patchCommand = `kubectl patch deployment ${deployment} -p "${metaData}" --record`;
-  // console.info(patchCommand);
-  // Note: exec does not work with escaped double quotes
-  const execSync = require('child_process').execSync;
-  console.info(execSync(patchCommand, { encoding: 'utf-8' }));
 }
 
 export async function rollout(options) {
@@ -134,8 +63,7 @@ export async function rollout(options) {
   if (!devMode) assertBedrockRoot();
 
   const config = await getConfig(environment);
-  const valid = await checkGCloudConfig(environment, config.gcloud);
-  if (!valid) exit('Invalid Google Cloud config');
+  await checkConfig(environment, config);
 
   await rolloutDeployment(environment, service, subservice);
 }

--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -203,11 +203,10 @@ export async function provision(options) {
 }
 
 export async function shell(options) {
-  const { service, subservice } = options;
   if (!devMode) assertBedrockRoot();
 
+  const { service, subservice } = options;
   const environment = options.environment || (await getEnvironmentPrompt());
-
   await checkKubectlVersion();
   const config = await getConfig(environment);
   await checkConfig(environment, config);
@@ -246,9 +245,9 @@ export async function shell(options) {
 }
 
 export async function logs(options) {
-  const { environment, service, subservice } = options;
   if (!devMode) assertBedrockRoot();
 
+  const { environment, service, subservice } = options;
   const config = await getConfig(environment);
   await checkConfig(environment, config);
   const { project, computeZone, kubernetes, label } = config.gcloud;

--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -159,12 +159,12 @@ export async function shell(options) {
   const config = await getConfig(environment);
   await checkConfig(environment, config);
 
-  const podsJSON = await exec(`kubectl get pods -o jsonpath='{.items}' --ignore-not-found`);
+  const podsJSON = await exec(`kubectl get pods -o json --ignore-not-found`);
   if (!podsJSON) {
     console.info(kleur.yellow(`No running pods`));
     process.exit(0);
   }
-  const pods = JSON.parse(podsJSON.slice(1, -1));
+  const pods = JSON.parse(podsJSON).items;
 
   let deployment = 'api-cli-deployment';
   if (service) {
@@ -179,7 +179,7 @@ export async function shell(options) {
   }
 
   const podName = filteredPods[0].metadata.name;
-  console.info(kleur.green(`=> Starting bash for pod: "${podName}"`));
+  console.info(kleur.yellow(`=> Starting bash for pod: "${podName}"`));
 
   const { spawn } = require('child_process');
 

--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -19,10 +19,8 @@ import {
   getPlatformName,
 } from './utils';
 
-const devMode = true;
-
 export async function authorize(options) {
-  if (!devMode) await assertBedrockRoot();
+  await assertBedrockRoot();
 
   const environment = options.environment || (await getEnvironmentPrompt());
   const config = await getConfig(environment);
@@ -31,7 +29,7 @@ export async function authorize(options) {
 }
 
 export async function status(options) {
-  if (!devMode) assertBedrockRoot();
+  await assertBedrockRoot();
   await checkKubectlVersion();
 
   const environment = options.environment || (await getEnvironmentPrompt());
@@ -48,7 +46,7 @@ export async function status(options) {
 }
 
 export async function build(options) {
-  if (!devMode) await assertBedrockRoot();
+  await assertBedrockRoot();
 
   const { service, subservice, tag } = options;
   const platformName = getPlatformName();
@@ -67,7 +65,7 @@ export async function build(options) {
 }
 
 export async function push(options) {
-  if (!devMode) assertBedrockRoot();
+  await assertBedrockRoot();
 
   const { service, subservice, tag } = options;
   const environment = options.environment || (await getEnvironmentPrompt());
@@ -89,7 +87,7 @@ export async function push(options) {
 }
 
 export async function rollout(options) {
-  if (!devMode) assertBedrockRoot();
+  await assertBedrockRoot();
   await checkKubectlVersion();
 
   const { service, subservice } = options;
@@ -108,7 +106,7 @@ export async function rollout(options) {
 }
 
 export async function deploy(options) {
-  if (!devMode) assertBedrockRoot();
+  await assertBedrockRoot();
   await checkKubectlVersion();
 
   const { service, subservice, tag } = options;
@@ -137,7 +135,7 @@ export async function deploy(options) {
 }
 
 export async function undeploy(options) {
-  if (!devMode) assertBedrockRoot();
+  await assertBedrockRoot();
 
   const { service, subservice } = options;
   const environment = options.environment || (await getEnvironmentPrompt());
@@ -167,7 +165,7 @@ async function showDeploymentInfo(service, subservice) {
 }
 
 export async function info(options) {
-  if (!devMode) assertBedrockRoot();
+  await assertBedrockRoot();
   await checkKubectlVersion();
 
   const { service, subservice } = options;
@@ -186,7 +184,7 @@ export async function info(options) {
 }
 
 export async function provision(options) {
-  if (!devMode) assertBedrockRoot();
+  await assertBedrockRoot();
 
   const environment = options.environment || (await getEnvironmentPrompt());
   const terraform = options.terraform || (await getTerraformPrompt());
@@ -203,7 +201,7 @@ export async function provision(options) {
 }
 
 export async function shell(options) {
-  if (!devMode) assertBedrockRoot();
+  await assertBedrockRoot();
 
   const { service, subservice } = options;
   const environment = options.environment || (await getEnvironmentPrompt());
@@ -245,7 +243,7 @@ export async function shell(options) {
 }
 
 export async function logs(options) {
-  if (!devMode) assertBedrockRoot();
+  await assertBedrockRoot();
 
   const { environment, service, subservice } = options;
   const config = await getConfig(environment);

--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -48,3 +48,25 @@ export async function status(options) {
   console.info(await exec('kubectl get nodes'), '\n');
   console.info(await exec('kubectl get pods'));
 }
+
+// function buildImage(service, subservice, tag) {}
+
+export async function build(options) {
+  const { service, subservice, tag = 'latest' } = options;
+
+  // await assertBedrockRoot();
+  // const config = await getConfig(environment);
+  const platformName = path.basename(process.cwd()); // || config.platformName
+  console.log(platformName);
+
+  await process.chdir('./services/api');
+  if (!subservice) {
+    const imageName = `${platformName}-services-${service}:${tag}`;
+    console.info(`=> Building "${imageName}"`);
+    console.info(await exec(`docker build -t ${imageName} .`));
+  } else {
+    const imageName = `${platformName}-services-${service}-${subservice}:${tag}`;
+    console.info(`=> Building "${imageName}"`);
+    console.info(await exec(`docker build -t ${imageName} -f Dockerfile.${subservice} .`));
+  }
+}

--- a/src/cloud/provision.js
+++ b/src/cloud/provision.js
@@ -1,0 +1,74 @@
+import path from 'path';
+import kleur from 'kleur';
+import { prompt } from '../util/prompt';
+import { exec, execSyncInherit } from '../util/shell';
+
+async function plan(options, planFile) {
+  const { project, computeZone, kubernetes, bucketPrefix, envName } = options;
+  // computeZone example: us-east1-c
+  const region = computeZone.slice(0, -2); // e.g. us-east1
+  const zone = computeZone.slice(-1); // e.g. c
+  const { clusterName, nodePoolCount, minNodeCount, maxNodeCount, machineType } = kubernetes;
+  console.info(kleur.green(`=> Planning with planFile: "${planFile}"`));
+  await execSyncInherit(
+    `terraform plan -var "project=${project}" -var "environment=${envName}" -var "cluster_name=${clusterName}" -var "bucket_prefix=${bucketPrefix}" -var "region=${region}" -var "zone=${zone}" -var "node_pool_count=${nodePoolCount}" -var "min_node_count=${minNodeCount}" -var "max_node_count=${maxNodeCount}" -var "machine_type=${machineType}" -out="${planFile}"`
+  );
+}
+
+export async function provisionTerraform(environment, terraform, options) {
+  const { project, computeZone, envName, bucketPrefix } = options;
+  const region = computeZone.slice(0, -2);
+
+  const planFile = await exec('mktemp');
+  process.chdir(path.resolve('deployment', 'environments', environment, 'provisioning'));
+
+  if (terraform == 'init') {
+    const terraformBucket = `${bucketPrefix}-terraform-system-state`;
+    console.info(kleur.green(`Terraform bucket: ${terraformBucket}`));
+    try {
+      await exec(`gsutil ls gs://${terraformBucket}`);
+    } catch (e) {
+      if (e.message.includes('BucketNotFoundException')) {
+        console.info(kleur.yellow(`${terraformBucket} does not exist. Creating now...`));
+        await exec(`gsutil mb -l ${region} gs://${terraformBucket}`);
+      }
+    }
+    console.info('Initialization can take several minutes...');
+    let command = `terraform init -backend-config="bucket=${terraformBucket}" -backend-config="prefix=${envName}"`;
+    console.info(command);
+    await execSyncInherit(command);
+  } else if (terraform == 'plan') {
+    await plan(options, planFile);
+  } else if (terraform == 'apply') {
+    await plan(options, planFile);
+    console.info(kleur.yellow('---------------------------------------------------------\n'));
+    console.info(kleur.yellow('         Applying plan can take several minutes          \n'));
+    console.info(kleur.yellow('---------------------------------------------------------\n'));
+    console.info(kleur.yellow(`Project: ${project}\nEnvironment: ${environment}\n`));
+
+    let confirmed = await prompt({
+      type: 'confirm',
+      name: 'apply',
+      message: 'Are you sure?',
+    });
+    if (!confirmed) process.exit(0);
+    await execSyncInherit(`terraform apply "${planFile}"`);
+  } else if (terraform == 'destroy') {
+    console.info('Resources to destroy:');
+    await execSyncInherit('terraform state list');
+    console.info(kleur.yellow('---------------------------------------------------------\n'));
+    console.info(kleur.yellow('    Destroying infrastructure can take several minutes   \n'));
+    console.info(kleur.yellow('---------------------------------------------------------\n'));
+    console.info(kleur.yellow(`Project: ${project}\nEnvironment: ${environment}\n`));
+
+    let confirmed = await prompt({
+      type: 'confirm',
+      name: 'destroy',
+      message: 'Are you sure?',
+    });
+    if (!confirmed) process.exit(0);
+    await execSyncInherit(`terraform destroy -auto-approve`);
+  } else {
+    console.info(kleur.yellow(`Terraform command "${terraform}" not supported`));
+  }
+}

--- a/src/cloud/push.js
+++ b/src/cloud/push.js
@@ -33,7 +33,7 @@ export async function dockerPush(project, platformName, service, subservice, tag
     images.length
       ? console.info(kleur.yellow('\n=> Pushing images:'))
       : console.info(kleur.yellow('No images found'));
-    images.forEach((image) => console.log('-', image));
+    images.forEach((image) => console.info('-', image));
 
     for (const image of images) {
       await pushImage(project, image, tag);

--- a/src/cloud/push.js
+++ b/src/cloud/push.js
@@ -31,8 +31,8 @@ export async function dockerPush(project, platformName, service, subservice, tag
       images = repositories.filter((repo) => repo.startsWith(`${platformName}-services-`));
     }
 
-    console.info('Images:');
-    console.info('-', images.join('\r\n- '));
+    images.length ? console.info('Images:') : console.info(kleur.yellow('No images found'));
+    images.forEach((image) => console.log('-', image));
 
     for (const image of images) {
       await pushImage(project, image, tag);

--- a/src/cloud/push.js
+++ b/src/cloud/push.js
@@ -1,0 +1,43 @@
+import { exit } from '../util/exit';
+import kleur from 'kleur';
+import { exec } from '../util/shell';
+
+async function pushImage(project, image, tag) {
+  const gcrTag = `gcr.io/${project}/${image}:${tag}`;
+  console.info(kleur.green(`Pushing ${gcrTag}`));
+  await exec(`docker tag ${image}:${tag} ${gcrTag}`);
+  const pushOutput = await exec(`docker push ${gcrTag}`);
+  console.info(pushOutput.split('\n').slice(-1)[0]);
+}
+
+export async function dockerPush(project, platformName, service, subservice, tag) {
+  try {
+    const dockerImages = await exec(`docker images --format "{{json . }}"`);
+    const dockerImagesJSON = dockerImages.split('\n').map((image) => {
+      return JSON.parse(image.slice(1, -1));
+    });
+    const repositories = dockerImagesJSON
+      .filter((image) => image.Tag == tag)
+      .map((image) => image.Repository);
+
+    let images = [];
+    if (subservice) {
+      images = repositories.filter(
+        (repo) => repo == `${platformName}-services-${service}-${subservice}`
+      );
+    } else if (service) {
+      images = repositories.filter((repo) => repo == `${platformName}-services-${service}`);
+    } else {
+      images = repositories.filter((repo) => repo.startsWith(`${platformName}-services-`));
+    }
+
+    console.info('Images:');
+    console.info('-', images.join('\r\n- '));
+
+    for (const image of images) {
+      await pushImage(project, image, tag);
+    }
+  } catch (e) {
+    exit(e.message);
+  }
+}

--- a/src/cloud/push.js
+++ b/src/cloud/push.js
@@ -1,14 +1,12 @@
 import { exit } from '../util/exit';
 import kleur from 'kleur';
-import { exec } from '../util/shell';
+import { exec, execSyncInherit } from '../util/shell';
 
 async function pushImage(project, image, tag) {
   const gcrTag = `gcr.io/${project}/${image}:${tag}`;
   console.info(kleur.green(`Pushing ${gcrTag}`));
   await exec(`docker tag ${image}:${tag} ${gcrTag}`);
-  require('child_process').execSync(`docker push ${gcrTag}`, {
-    stdio: 'inherit',
-  });
+  execSyncInherit(`docker push ${gcrTag}`);
 }
 
 export async function dockerPush(project, platformName, service, subservice, tag = 'latest') {

--- a/src/cloud/push.js
+++ b/src/cloud/push.js
@@ -10,7 +10,7 @@ async function pushImage(project, image, tag) {
   console.info(pushOutput.split('\n').slice(-1)[0]);
 }
 
-export async function dockerPush(project, platformName, service, subservice, tag) {
+export async function dockerPush(project, platformName, service, subservice, tag = 'latest') {
   try {
     const dockerImages = await exec(`docker images --format "{{json . }}"`);
     const dockerImagesJSON = dockerImages.split('\n').map((image) => {
@@ -31,7 +31,9 @@ export async function dockerPush(project, platformName, service, subservice, tag
       images = repositories.filter((repo) => repo.startsWith(`${platformName}-services-`));
     }
 
-    images.length ? console.info('Images:') : console.info(kleur.yellow('No images found'));
+    images.length
+      ? console.info(kleur.yellow('\n=> Pushing images:'))
+      : console.info(kleur.yellow('No images found'));
     images.forEach((image) => console.log('-', image));
 
     for (const image of images) {

--- a/src/cloud/push.js
+++ b/src/cloud/push.js
@@ -6,8 +6,9 @@ async function pushImage(project, image, tag) {
   const gcrTag = `gcr.io/${project}/${image}:${tag}`;
   console.info(kleur.green(`Pushing ${gcrTag}`));
   await exec(`docker tag ${image}:${tag} ${gcrTag}`);
-  const pushOutput = await exec(`docker push ${gcrTag}`);
-  console.info(pushOutput.split('\n').slice(-1)[0]);
+  require('child_process').execSync(`docker push ${gcrTag}`, {
+    stdio: 'inherit',
+  });
 }
 
 export async function dockerPush(project, platformName, service, subservice, tag = 'latest') {

--- a/src/cloud/rollout.js
+++ b/src/cloud/rollout.js
@@ -1,0 +1,57 @@
+import { exec } from '../util/shell';
+import fs from 'fs';
+import path from 'path';
+
+async function getTag() {
+  let tag = await exec('git tag --points-at HEAD');
+  if (!tag) tag = await exec('git rev-parse --short --verify HEAD');
+  const stat = await exec('git diff --stat');
+  if (stat) tag += '-dirty';
+  return tag;
+}
+
+async function getMetaData() {
+  const author = await exec('git config user.name');
+  const date = new Date().toUTCString();
+  const branch = await exec('git branch --show-current');
+  const git = await getTag();
+  let fields = `\\"author\\":\\"${author}\\"`;
+  fields += `,\\"date\\":\\"${date}\\"`;
+  fields += `,\\"branch\\":\\"${branch}\\"`;
+  fields += `,\\"git\\":\\"${git}\\"`;
+  const metaData = `{\\"spec\\":{\\"template\\":{\\"metadata\\":{\\"annotations\\":{${fields}}}}}}`;
+  return metaData;
+}
+
+export async function rolloutDeployment(environment, service, subservice) {
+  let deployment = service;
+  if (subservice) deployment += `-${subservice}`;
+  deployment += '-deployment';
+
+  console.info(`Rolling out ${environment} ${deployment}`);
+
+  const deploymentFile = path.resolve(
+    'deployment',
+    'environments',
+    environment,
+    'services',
+    `${deployment}.yml`
+  );
+
+  // Check for config file as it might not exist if the
+  // deployment was dynamically created for a feature branch.
+  if (fs.existsSync(deploymentFile)) {
+    const applyCommand = `kubectl apply -f ${deploymentFile} --record`;
+    // console.info(applyCommand);
+    console.info(await exec(applyCommand));
+  }
+
+  const metaData = await getMetaData();
+  // Patching spec.template forces the container to pull the latest image and
+  // perform a rolling update as long as imagePullPolicy: Always is specified.
+  const patchCommand = `kubectl patch deployment ${deployment} -p "${metaData}" --record`;
+  // console.info(patchCommand);
+  // Note: exec does not work with escaped double quotes
+  const execSync = require('child_process').execSync;
+  console.info(execSync(patchCommand, { encoding: 'utf-8' }));
+}

--- a/src/cloud/rollout.js
+++ b/src/cloud/rollout.js
@@ -1,3 +1,4 @@
+import kleur from 'kleur';
 import { exec } from '../util/shell';
 import fs from 'fs';
 import path from 'path';
@@ -28,7 +29,7 @@ export async function rolloutDeployment(environment, service, subservice) {
   if (subservice) deployment += `-${subservice}`;
   deployment += '-deployment';
 
-  console.info(`Rolling out ${environment} ${deployment}`);
+  console.info(kleur.yellow(`\n=> Rolling out ${environment} ${deployment}`));
 
   const deploymentFile = path.resolve(
     'deployment',
@@ -53,5 +54,6 @@ export async function rolloutDeployment(environment, service, subservice) {
   // console.info(patchCommand);
   // Note: exec does not work with escaped double quotes
   const execSync = require('child_process').execSync;
+
   console.info(execSync(patchCommand, { encoding: 'utf-8' }));
 }

--- a/src/cloud/rollout.js
+++ b/src/cloud/rollout.js
@@ -84,11 +84,11 @@ export async function checkDeployment(service, subservice) {
   const deployment = getDeployment(service, subservice);
 
   const deploymentInfoJSON = await exec(
-    `kubectl get deployment ${deployment} -o jsonpath='{@}' --ignore-not-found`
+    `kubectl get deployment ${deployment} -o json --ignore-not-found`
   );
   if (!deploymentInfoJSON) {
     console.info(kleur.yellow(`Deployment "${deployment}" could not be found`));
     process.exit(0);
   }
-  return JSON.parse(deploymentInfoJSON.slice(1, -1));
+  return JSON.parse(deploymentInfoJSON);
 }

--- a/src/cloud/rollout.js
+++ b/src/cloud/rollout.js
@@ -3,6 +3,13 @@ import { exec } from '../util/shell';
 import fs from 'fs';
 import path from 'path';
 
+export function getDeployment(service, subservice) {
+  let deployment = service;
+  if (subservice) deployment += `-${subservice}`;
+  deployment += '-deployment';
+  return deployment;
+}
+
 async function getTag() {
   let tag = await exec('git tag --points-at HEAD');
   if (!tag) tag = await exec('git rev-parse --short --verify HEAD');
@@ -25,10 +32,7 @@ async function getMetaData() {
 }
 
 export async function rolloutDeployment(environment, service, subservice) {
-  let deployment = service;
-  if (subservice) deployment += `-${subservice}`;
-  deployment += '-deployment';
-
+  const deployment = getDeployment(service, subservice);
   console.info(kleur.yellow(`\n=> Rolling out ${environment} ${deployment}`));
 
   const deploymentFile = path.resolve(

--- a/src/cloud/rollout.js
+++ b/src/cloud/rollout.js
@@ -1,5 +1,5 @@
 import kleur from 'kleur';
-import { exec } from '../util/shell';
+import { exec, execSyncInherit } from '../util/shell';
 import fs from 'fs';
 import path from 'path';
 
@@ -48,7 +48,7 @@ export async function rolloutDeployment(environment, service, subservice) {
   if (fs.existsSync(deploymentFile)) {
     const applyCommand = `kubectl apply -f ${deploymentFile} --record`;
     // console.info(applyCommand);
-    console.info(await exec(applyCommand));
+    await execSyncInherit(applyCommand);
   }
 
   const metaData = await getMetaData();
@@ -56,8 +56,5 @@ export async function rolloutDeployment(environment, service, subservice) {
   // perform a rolling update as long as imagePullPolicy: Always is specified.
   const patchCommand = `kubectl patch deployment ${deployment} -p "${metaData}" --record`;
   // console.info(patchCommand);
-  // Note: exec does not work with escaped double quotes
-  const execSync = require('child_process').execSync;
-
-  console.info(execSync(patchCommand, { encoding: 'utf-8' }));
+  execSyncInherit(patchCommand);
 }

--- a/src/cloud/rollout.js
+++ b/src/cloud/rollout.js
@@ -93,7 +93,7 @@ export async function checkDeployment(service, subservice) {
   );
   if (!deploymentInfoJSON) {
     console.info(kleur.yellow(`Deployment "${deployment}" could not be found`));
-    process.exit(0);
+    return false;
   }
   return JSON.parse(deploymentInfoJSON);
 }

--- a/src/cloud/utils.js
+++ b/src/cloud/utils.js
@@ -1,0 +1,100 @@
+import fs from 'fs';
+import path from 'path';
+import compareVersions from 'compare-versions';
+import { prompt } from '../util/prompt';
+import { exit } from '../util/exit';
+import { exec } from '../util/shell';
+
+export function getPlatformName() {
+  return path.basename(process.cwd());
+}
+
+function getDirectories(folder) {
+  if (fs.existsSync(folder)) {
+    return fs.readdirSync(folder).filter((file) => {
+      const filePath = path.resolve(folder, file);
+      return fs.lstatSync(filePath).isDirectory();
+    });
+  }
+  return [];
+}
+
+function getEnvironments() {
+  return getDirectories(path.resolve('deployment', 'environments')).reverse();
+}
+
+export async function getEnvironmentPrompt() {
+  return await prompt({
+    type: 'select',
+    message: 'Select environment:',
+    choices: getEnvironments().map((value) => {
+      return { title: value, value };
+    }),
+  });
+}
+
+function getServices() {
+  const services = [];
+  const servicesFolders = getDirectories('services');
+  for (const serviceFolder of servicesFolders) {
+    for (const file of fs.readdirSync(path.resolve('services', serviceFolder))) {
+      if (file == 'Dockerfile') {
+        services.push([serviceFolder.toString(), '']);
+      } else if (file.startsWith('Dockerfile.')) {
+        services.push([serviceFolder.toString(), file.toString().replace('Dockerfile.', '')]);
+      }
+    }
+  }
+  return services;
+}
+
+export async function getServicesPrompt() {
+  const services = getServices();
+  return await prompt({
+    type: 'multiselect',
+    hint: '- Space or arrow-keys to select. Press "a" to select all. Return to submit.',
+    message: 'Select service / subservice:',
+    instructions: false,
+    choices: services.map(([service, subservice]) => {
+      let title = service;
+      if (subservice) title = `${service} / ${subservice}`;
+      return { title, value: [service, subservice] };
+    }),
+  });
+}
+
+export async function getTagPrompt() {
+  return await prompt({
+    type: 'text',
+    message: 'Enter build tag:',
+    initial: 'latest',
+  });
+}
+
+export async function getTerraformPrompt() {
+  const terraformCommands = ['init', 'plan', 'apply', 'destroy'];
+  return await prompt({
+    type: 'select',
+    message: 'Select terraform command:',
+    initial: 1,
+    choices: terraformCommands.map((value) => {
+      return { title: value, value };
+    }),
+  });
+}
+
+export async function checkKubectlVersion(minVersion = 'v1.19.0') {
+  try {
+    const kubectlVersion = await exec('kubectl version --client -o json');
+    const parsed = JSON.parse(kubectlVersion);
+    const version = parsed.clientVersion.gitVersion;
+    if (compareVersions.compare(minVersion, version, '>')) {
+      exit(
+        `Error: Minimum required "kubectl" version is "${minVersion}", you have "${version}". On macos run "brew upgrade kubernetes-cli."`
+      );
+    }
+  } catch (e) {
+    console.error(e);
+    exit('Error: failed to parse kubectl version');
+  }
+}

--- a/src/util/exit.js
+++ b/src/util/exit.js
@@ -1,0 +1,6 @@
+import kleur from 'kleur';
+
+export function exit(message) {
+  console.info(kleur.red(message));
+  process.exit(1);
+}

--- a/src/util/shell.js
+++ b/src/util/shell.js
@@ -1,6 +1,6 @@
 import execa from 'execa';
 
-export async function exec(commands) {
+export async function exec(commands, stdErr = false) {
   try {
     if (typeof commands === 'string') {
       commands = [commands];
@@ -8,10 +8,11 @@ export async function exec(commands) {
     let output = '';
     for (let command of commands) {
       const [first, ...rest] = command.match(/".+"|\S+/g);
-      output = (await execa(first, rest)).stdout;
+      const execResult = await execa(first, rest);
+      output = stdErr ? execResult.stderr : execResult.stdout;
     }
     return output;
-  } catch(err) {
+  } catch (err) {
     const { stderr, stdout } = err;
     const message = (stderr || stdout).split('\n').join(' ');
     throw new Error(message);

--- a/src/util/shell.js
+++ b/src/util/shell.js
@@ -20,10 +20,9 @@ export async function exec(commands, std = `stdout`) {
   }
 }
 
+// Use when you need to pass through the corresponding stdio stream to the Node.js script output.
+// This facilitates live updates to the output, e.g., when "watching" output or pushing docker images.
+// See: https://stackoverflow.com/a/31104898
 export async function execSyncInherit(command) {
   await execSync(command, { stdio: 'inherit' });
-}
-
-export async function execSyncPipe(command) {
-  return await execSync(command, { stdio: 'pipe', encoding: 'utf-8' });
 }

--- a/src/util/shell.js
+++ b/src/util/shell.js
@@ -1,6 +1,6 @@
 import execa from 'execa';
 
-export async function exec(commands, stdErr = false) {
+export async function exec(commands, std = `stdout`) {
   try {
     if (typeof commands === 'string') {
       commands = [commands];
@@ -9,7 +9,7 @@ export async function exec(commands, stdErr = false) {
     for (let command of commands) {
       const [first, ...rest] = command.match(/".+"|\S+/g);
       const execResult = await execa(first, rest);
-      output = stdErr ? execResult.stderr : execResult.stdout;
+      output = std == 'stderr' ? execResult.stderr : execResult.stdout;
     }
     return output;
   } catch (err) {

--- a/src/util/shell.js
+++ b/src/util/shell.js
@@ -1,4 +1,5 @@
 import execa from 'execa';
+import { execSync } from 'child_process';
 
 export async function exec(commands, std = `stdout`) {
   try {
@@ -17,4 +18,12 @@ export async function exec(commands, std = `stdout`) {
     const message = (stderr || stdout).split('\n').join(' ');
     throw new Error(message);
   }
+}
+
+export async function execSyncInherit(command) {
+  await execSync(command, { stdio: 'inherit' });
+}
+
+export async function execSyncPipe(command) {
+  return await execSync(command, { stdio: 'pipe', encoding: 'utf-8' });
 }

--- a/src/util/sleep.js
+++ b/src/util/sleep.js
@@ -1,0 +1,3 @@
+export async function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,6 +1766,11 @@ commander@^6.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz#f8d722b78103141006b66f4c7ba1e97315ba75bc"
   integrity sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==
 
+compare-versions@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"


### PR DESCRIPTION
Added cloud commands:

<img width="854" alt="Screenshot 2020-12-07 at 22 28 47" src="https://user-images.githubusercontent.com/90617/101407747-a27c9900-38db-11eb-84fe-ed0ad8cf01fb.png">

Notes:
- Added the use of `execSync`, instead of the `util/shell` exec, which didn't handle double quotes
- Added `execSyncInherit` to allow live console output updates (pass through)
- Added the use of `child_process spawn` also with inherit, to allow login into remote containers with bash taking over

Still todo: 
- Update and warn secrets
- Allow deployment of feature-branches
- Update original documentation of deployment scripts
