### PR TITLE
fix: update docker compose command ref

### DIFF
--- a/src/create/index.js
+++ b/src/create/index.js
@@ -107,7 +107,7 @@ export default async function create(options) {
 
   To run the stack with Docker:
 
-  docker-compose up
+  docker compose up
 
   To prepare for deployment:
 


### PR DESCRIPTION
`docker compose up` should be used instead of old `docker-compose` command. Small change, but still allows just and copy, paste and execute the [command](https://docs.docker.com/compose/releases/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2).